### PR TITLE
Add info about streaming API into readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -46,6 +46,10 @@ There's also a Ruby API.
 
 As well as just passing an email, there are a number of additional options you can send to `Clearbit::LeadScore.lookup`, such as the weights that are used internally. You could also just use the information returned to calculate your own score.
 
+This method uses the [Clearbit Streaming API](https://clearbit.com/docs#streaming) which is especially useful if you're making long-lived requests (i.e. you’re making requests to Clearbit from a messaging queue).
+
+This method returns a hash with **both** person and company data, assuming data for both are available. Otherwise, `result.person` or `result.company` will return `nil`
+
 The default options are:
 
     {

--- a/leadscore.gemspec
+++ b/leadscore.gemspec
@@ -19,7 +19,7 @@ Gem::Specification.new do |spec|
 
   spec.add_development_dependency "bundler", "~> 1.6"
   spec.add_development_dependency "rake"
-  spec.add_dependency "clearbit", "~> 0.0.5"
+  spec.add_dependency "clearbit", "~> 0.1.1"
   spec.add_dependency "awesome_print"
   spec.add_dependency "thread"
 end


### PR DESCRIPTION
Not sure why it thinks the gemspec update is new, it's the same as what's in master. Shouldn't create any conflicts on merge though